### PR TITLE
chore: remove deprecated action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,16 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Rust 🦀
-        uses: rust-lang/simpleinfra/github-actions/simple-ci@master
-        with:
-          check_fmt: true
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Build
+        run: cargo build --tests --workspace
+
+      - name: Test
+        run: cargo test --workspace


### PR DESCRIPTION
Hi, I'm Marco from the Rust Infra team 👋

As described in https://github.com/rust-lang/simpleinfra/issues/445 we want to delete the `simple-ci` GitHub action.

This PR substitutes the action with the equivalent commands 👍

Let me know if you have any questions 🙏

